### PR TITLE
HGI-10507: migrate to SDK + emit target state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
-singer-sdk = "^0.9.0"
-target-hotglue = "^0.1.11"
+hotglue-singer-sdk = "^1.0.40"
 netsuitesdk = { git = "https://github.com/hotgluexyz/netsuite-sdk-py.git", tag = "2.8.0" }
 requests-oauthlib = "^1.3.1"
 xmltodict = "^0.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
-singer-sdk = "^0.5.0"
+singer-sdk = "^0.9.0"
+target-hotglue = "^0.1.11"
 netsuitesdk = { git = "https://github.com/hotgluexyz/netsuite-sdk-py.git", tag = "2.8.0" }
 requests-oauthlib = "^1.3.1"
 xmltodict = "^0.12.0"

--- a/target_netsuite_v2/rest_client.py
+++ b/target_netsuite_v2/rest_client.py
@@ -1,6 +1,6 @@
 """netsuite-v2 target sink class, which handles writing streams."""
 
-from singer_sdk.sinks import BatchSink
+from target_hotglue.sinks import HotglueSink
 import requests
 from oauthlib import oauth1
 from requests_oauthlib import OAuth1
@@ -11,8 +11,15 @@ import ast
 import xmltodict
 
 
-class netsuiteRestV2Sink(BatchSink):
+class netsuiteRestV2Sink(HotglueSink):
     """netsuite-v2 target sink class."""
+
+    def _extract_id_from_response_header(self, headers):
+        location = headers.get("Location")
+        #example 'Location': 'https://{ns_account}.suitetalk.api.netsuite.com/services/rest/record/v1/customer/{id}'
+        if not location:
+            return None
+        return location.split("/")[-1]
 
     @property
     def url_account(self) -> str:
@@ -252,9 +259,9 @@ class netsuiteRestV2Sink(BatchSink):
         items = []
 
         # Get the NetSuite Customer Ref
-        if context["reference_data"].get("Customer") and record.get("customer_name"):
+        if self.reference_data.get("Customer") and record.get("customer_name"):
             customer_names = []
-            for c in context["reference_data"]["Customer"]:
+            for c in self.reference_data["Customer"]:
                 if "name" in c.keys():
                     if c["name"]:
                         customer_names.append(c["name"])
@@ -267,7 +274,7 @@ class netsuiteRestV2Sink(BatchSink):
             if customer_name:
                 customer_name = max(customer_name, key=customer_name.get)
                 customer_data = []
-                for c in context["reference_data"]["Customer"]:
+                for c in self.reference_data["Customer"]:
                     if "name" in c.keys():
                         if c["name"] == customer_name:
                             customer_data.append(c)
@@ -286,9 +293,9 @@ class netsuiteRestV2Sink(BatchSink):
             order_item = {}
 
             # Get the product Id
-            if context["reference_data"].get("Items") and line.get("product_name"):
+            if self.reference_data.get("Items") and line.get("product_name"):
                 product_names = [
-                    c["itemId"] for c in context["reference_data"]["Items"]
+                    c["itemId"] for c in self.reference_data["Items"]
                 ]
                 product_name = self.get_close_matches(
                     line["product_name"], product_names, n=2, cutoff=0.95
@@ -297,7 +304,7 @@ class netsuiteRestV2Sink(BatchSink):
                     product_name = max(product_name, key=product_name.get)
                     product_data = [
                         c
-                        for c in context["reference_data"]["Items"]
+                        for c in self.reference_data["Items"]
                         if c["itemId"] == product_name
                     ]
                     if product_data:
@@ -333,9 +340,9 @@ class netsuiteRestV2Sink(BatchSink):
             vendor_bill["entity"] = {
                 "id": record.get("vendorId", record.get("vendorNum"))
             }
-        elif context["reference_data"].get("Vendors") and record.get("vendorName"):
+        elif self.reference_data.get("Vendors") and record.get("vendorName"):
             vendor_names = []
-            for c in context["reference_data"]["Vendors"]:
+            for c in self.reference_data["Vendors"]:
                 if "entityId" in c.keys():
                     vendor_names.append(c["entityId"])
             vendor_name = self.get_close_matches(
@@ -344,7 +351,7 @@ class netsuiteRestV2Sink(BatchSink):
             if vendor_name:
                 vendor_name = max(vendor_name, key=vendor_name.get)
                 vendor_data = []
-                for c in context["reference_data"]["Vendors"]:
+                for c in self.reference_data["Vendors"]:
                     if c["entityId"] == vendor_name:
                         vendor_data.append(c)
                 if vendor_data:
@@ -368,10 +375,10 @@ class netsuiteRestV2Sink(BatchSink):
         location = None
         if record.get("locationId"):
             location = {"id": record["locationId"]}
-        elif context["reference_data"].get("Locations") and record.get("location"):
+        elif self.reference_data.get("Locations") and record.get("location"):
             loc_data = [
                 l
-                for l in context["reference_data"]["Locations"]
+                for l in self.reference_data["Locations"]
                 if l["name"] == record["location"]
             ]
             if loc_data:
@@ -381,10 +388,10 @@ class netsuiteRestV2Sink(BatchSink):
         department = None
         if record.get("departmentId"):
             department = {"id": record["departmentId"]}
-        elif context["reference_data"].get("Departments") and record.get("department"):
+        elif self.reference_data.get("Departments") and record.get("department"):
             dep_data = [
                 d
-                for d in context["reference_data"]["Departments"]
+                for d in self.reference_data["Departments"]
                 if d["name"] == record["department"]
             ]
             if dep_data:
@@ -407,10 +414,10 @@ class netsuiteRestV2Sink(BatchSink):
         # Get the NetSuite Subsidiary Ref
         if record.get("subsidiaryId"):
             vendor_bill["subsidiary"] = {"id": record.get("subsidiaryId")}
-        if context["reference_data"].get("Subsidiaries") and record.get("subsidiary"):
+        if self.reference_data.get("Subsidiaries") and record.get("subsidiary"):
             sub_data = [
                 s
-                for s in context["reference_data"]["Subsidiaries"]
+                for s in self.reference_data["Subsidiaries"]
                 if s["name"] == record["subsidiary"]
             ]
             if sub_data:
@@ -429,9 +436,9 @@ class netsuiteRestV2Sink(BatchSink):
             # Get the product Id
             if line.get("productId"):
                 order_item["item"] = {"id": line.get("productId")}
-            elif context["reference_data"].get("Items") and line.get("productName"):
+            elif self.reference_data.get("Items") and line.get("productName"):
                 product_names = [
-                    c["itemId"] for c in context["reference_data"]["Items"]
+                    c["itemId"] for c in self.reference_data["Items"]
                 ]
                 product_name = self.get_close_matches(
                     line["productName"], product_names, n=2, cutoff=0.95
@@ -440,7 +447,7 @@ class netsuiteRestV2Sink(BatchSink):
                     product_name = max(product_name, key=product_name.get)
                     product_data = [
                         c
-                        for c in context["reference_data"]["Items"]
+                        for c in self.reference_data["Items"]
                         if c["itemId"] == product_name
                     ]
                     if product_data:
@@ -455,12 +462,12 @@ class netsuiteRestV2Sink(BatchSink):
             elif line.get("departmentId"):
                 department = {"id": line["departmentId"]}
                 order_item["Department"] = department
-            elif context["reference_data"].get("Departments") and line.get(
+            elif self.reference_data.get("Departments") and line.get(
                 "department"
             ):
                 dep_data = [
                     d
-                    for d in context["reference_data"]["Departments"]
+                    for d in self.reference_data["Departments"]
                     if d["name"] == line["department"]
                 ]
                 if dep_data:
@@ -485,13 +492,13 @@ class netsuiteRestV2Sink(BatchSink):
             # Get the account Id
             if line.get("accountId"):
                 expense["account"] = {"id": line.get("accountId")}
-            elif context["reference_data"].get("Accounts") and line.get(
+            elif self.reference_data.get("Accounts") and line.get(
                 "accountNumber"
             ):
                 acct_num = str(line["accountNumber"])
                 acct_data = [
                     a
-                    for a in context["reference_data"]["Accounts"]
+                    for a in self.reference_data["Accounts"]
                     if a["acctNumber"] == acct_num
                 ]
                 if acct_data:
@@ -507,10 +514,10 @@ class netsuiteRestV2Sink(BatchSink):
             location = None
             if line.get("locationId"):
                 location = {"id": line["locationId"]}
-            elif context["reference_data"].get("Locations") and line.get("location"):
+            elif self.reference_data.get("Locations") and line.get("location"):
                 loc_data = [
                     l
-                    for l in context["reference_data"]["Locations"]
+                    for l in self.reference_data["Locations"]
                     if l["name"] == line["location"]
                 ]
                 if loc_data:
@@ -535,13 +542,13 @@ class netsuiteRestV2Sink(BatchSink):
             invoice["tranId"] = record["invoiceNumber"]
 
         # Get the NetSuite Customer Ref
-        if context["reference_data"].get("Customer"):
+        if self.reference_data.get("Customer"):
             customer_data = []
             if record.get("customerId"):
-                customer_data = [c for c in context["reference_data"]["Customer"] if c["internalId"] == record["customerId"]]
+                customer_data = [c for c in self.reference_data["Customer"] if c["internalId"] == record["customerId"]]
             if record.get("customerName") and not customer_data:
                 customer_names = []
-                for c in context["reference_data"]["Customer"]:
+                for c in self.reference_data["Customer"]:
                     if "name" in c.keys():
                         if c["name"]:
                             customer_names.append(c["name"])
@@ -554,7 +561,7 @@ class netsuiteRestV2Sink(BatchSink):
                 if customer_name:
                     customer_name = max(customer_name, key=customer_name.get)
                     customer_data = []
-                    for c in context["reference_data"]["Customer"]:
+                    for c in self.reference_data["Customer"]:
                         if "name" in c.keys():
                             if c["name"] == customer_name:
                                 customer_data.append(c)
@@ -566,10 +573,10 @@ class netsuiteRestV2Sink(BatchSink):
                 invoice["entity"] = {"id": customer_data.get("internalId")}
 
         # Get the NetSuite Location Ref
-        if context["reference_data"].get("Locations") and record.get("location"):
+        if self.reference_data.get("Locations") and record.get("location"):
             loc_data = [
                 l
-                for l in context["reference_data"]["Locations"]
+                for l in self.reference_data["Locations"]
                 if l["name"] == record["location"]
             ]
             if loc_data:
@@ -581,19 +588,19 @@ class netsuiteRestV2Sink(BatchSink):
             invoice["Location"] = location
 
         # Get the NetSuite Subsidiary Ref
-        if context["reference_data"].get("Subsidiaries") and record.get("subsidiary"):
+        if self.reference_data.get("Subsidiaries") and record.get("subsidiary"):
             # look for subsidiary id match 
             record["subsidiary"] = record["subsidiary"] if isinstance(record["subsidiary"], str) else str(record["subsidiary"]).split(".")[0]
             sub_data = [
                 s
-                for s in context["reference_data"]["Subsidiaries"]
+                for s in self.reference_data["Subsidiaries"]
                 if s["internalId"] == record["subsidiary"]
             ]
             # look for subsidiary name
             if not sub_data:
                 sub_data = [
                     s
-                    for s in context["reference_data"]["Subsidiaries"]
+                    for s in self.reference_data["Subsidiaries"]
                     if s["name"] == record["subsidiary"]
                 ]
             if sub_data:
@@ -626,9 +633,9 @@ class netsuiteRestV2Sink(BatchSink):
             # Get the product Id
             if "productId" in line:
                 order_item["item"] = {"id": line["productId"]}
-            elif context["reference_data"].get("Items") and line.get("productName"):
+            elif self.reference_data.get("Items") and line.get("productName"):
                 product_names = [
-                    c["itemId"] for c in context["reference_data"]["Items"]
+                    c["itemId"] for c in self.reference_data["Items"]
                 ]
                 product_name = self.get_close_matches(
                     line["productName"], product_names, n=2, cutoff=0.95
@@ -637,7 +644,7 @@ class netsuiteRestV2Sink(BatchSink):
                     product_name = max(product_name, key=product_name.get)
                     product_data = [
                         c
-                        for c in context["reference_data"]["Items"]
+                        for c in self.reference_data["Items"]
                         if c["itemId"] == product_name
                     ]
                     if product_data:
@@ -724,27 +731,27 @@ class netsuiteRestV2Sink(BatchSink):
 
         # field araccount uses the same account as the invoice and it's read-only
         # field account is the bank account that will be used to pay the invoice, it can only be passed if funds have been already deposited
-        if context["reference_data"].get("Accounts"):
+        if self.reference_data.get("Accounts"):
             acct_data = None
             if raw_record.get("accountId"):
                 acct_id = str(raw_record["accountId"])
                 acct_data = [
                     a
-                    for a in context["reference_data"]["Accounts"]
+                    for a in self.reference_data["Accounts"]
                     if a["internalId"] == acct_id
                 ]
             if not acct_data and raw_record.get("accountNumber"):
                 acct_num = str(raw_record["accountNumber"])
                 acct_data = [
                     a
-                    for a in context["reference_data"]["Accounts"]
+                    for a in self.reference_data["Accounts"]
                     if a["acctNumber"] == acct_num
                 ]
             if not acct_data and raw_record.get("accountName"):
                 acct_name = raw_record["accountName"]
                 acct_data = [
                     a
-                    for a in context["reference_data"]["Accounts"]
+                    for a in self.reference_data["Accounts"]
                     if a["acctName"] == acct_name
                 ]
             if acct_data:
@@ -762,11 +769,11 @@ class netsuiteRestV2Sink(BatchSink):
             if not acct_data and (raw_record.get("accountId") or raw_record.get("accountNumber")) or raw_record.get("accountName"):
                 raise ValueError(f"Account {raw_record.get('accountId') or raw_record.get('accountNumber') or raw_record.get('accountName')} not found in reference data")
         
-        if context["reference_data"].get("Currencies") and raw_record.get("currency"):
+        if self.reference_data.get("Currencies") and raw_record.get("currency"):
             currency_symbol = raw_record.get("currency")
             currency = [
                 c
-                for c in context["reference_data"]["Currencies"]
+                for c in self.reference_data["Currencies"]
                 if c["symbol"] == currency_symbol
             ]
             if currency:
@@ -854,27 +861,27 @@ class netsuiteRestV2Sink(BatchSink):
 
         # field araccount uses the same account as the invoice and it's read-only
         # field account is the bank account that will be used to pay the invoice, it can only be passed if funds have been already deposited
-        if context["reference_data"].get("Accounts"):
+        if self.reference_data.get("Accounts"):
             acct_data = None
             if raw_record.get("accountId"):
                 acct_id = str(raw_record["accountId"])
                 acct_data = [
                     a
-                    for a in context["reference_data"]["Accounts"]
+                    for a in self.reference_data["Accounts"]
                     if a["internalId"] == acct_id
                 ]
             if not acct_data and raw_record.get("accountNumber"):
                 acct_num = str(raw_record["accountNumber"])
                 acct_data = [
                     a
-                    for a in context["reference_data"]["Accounts"]
+                    for a in self.reference_data["Accounts"]
                     if a["acctNumber"] == acct_num
                 ]
             if not acct_data and raw_record.get("accountName"):
                 acct_name = raw_record["accountName"]
                 acct_data = [
                     a
-                    for a in context["reference_data"]["Accounts"]
+                    for a in self.reference_data["Accounts"]
                     if a["acctName"] == acct_name
                 ]
             if acct_data:
@@ -888,11 +895,11 @@ class netsuiteRestV2Sink(BatchSink):
                 raise ValueError(f"Account {raw_record.get('accountId') or raw_record.get('accountNumber') or raw_record.get('accountName')} not found in reference data")
 
         
-        if context["reference_data"].get("Currencies") and raw_record.get("currency"):
+        if self.reference_data.get("Currencies") and raw_record.get("currency"):
             currency_symbol = raw_record.get("currency")
             currency = [
                 c
-                for c in context["reference_data"]["Currencies"]
+                for c in self.reference_data["Currencies"]
                 if c["symbol"] == currency_symbol
             ]
             if currency:
@@ -914,9 +921,9 @@ class netsuiteRestV2Sink(BatchSink):
             vendor_credit["entity"] = {
                 "id": record.get("vendorId", record.get("vendorNum"))
             }
-        elif context["reference_data"].get("Vendors") and record.get("vendorName"):
+        elif self.reference_data.get("Vendors") and record.get("vendorName"):
             vendor_names = []
-            for c in context["reference_data"]["Vendors"]:
+            for c in self.reference_data["Vendors"]:
                 if "entityId" in c.keys():
                     vendor_names.append(c["entityId"])
             vendor_name = self.get_close_matches(
@@ -925,7 +932,7 @@ class netsuiteRestV2Sink(BatchSink):
             if vendor_name:
                 vendor_name = max(vendor_name, key=vendor_name.get)
                 vendor_data = []
-                for c in context["reference_data"]["Vendors"]:
+                for c in self.reference_data["Vendors"]:
                     if c["entityId"] == vendor_name:
                         vendor_data.append(c)
                 if vendor_data:
@@ -949,10 +956,10 @@ class netsuiteRestV2Sink(BatchSink):
         location = None
         if record.get("locationId"):
             location = {"id": record["locationId"]}
-        elif context["reference_data"].get("Locations") and record.get("location"):
+        elif self.reference_data.get("Locations") and record.get("location"):
             loc_data = [
                 l
-                for l in context["reference_data"]["Locations"]
+                for l in self.reference_data["Locations"]
                 if l["name"] == record["location"]
             ]
             if loc_data:
@@ -973,7 +980,7 @@ class netsuiteRestV2Sink(BatchSink):
 
                 if item.get("productName") and item_credit.get("item") is None:
                     product_names = [
-                        c["itemId"] for c in context["reference_data"]["Items"]
+                        c["itemId"] for c in self.reference_data["Items"]
                     ]
                     product_name = self.get_close_matches(
                         item["productName"], product_names, n=2, cutoff=0.95
@@ -982,7 +989,7 @@ class netsuiteRestV2Sink(BatchSink):
                         product_name = max(product_name, key=product_name.get)
                         product_data = [
                             c
-                            for c in context["reference_data"]["Items"]
+                            for c in self.reference_data["Items"]
                             if c["itemId"] == product_name
                         ]
                         if product_data:
@@ -1164,7 +1171,7 @@ class netsuiteRestV2Sink(BatchSink):
         return res
 
     def process_customer(self, context, record):
-        customers = context["reference_data"]["Customer"]
+        customers = self.reference_data["Customer"]
         subsidiary = record.get("subsidiary")
         sales_rep = record.get("ownerId")
         first_name = None
@@ -1271,7 +1278,7 @@ class netsuiteRestV2Sink(BatchSink):
             customer = list(
                 filter(
                     lambda x: x["companyName"] == record.get("customerName"),
-                    context["reference_data"]["Customer"],
+                    self.reference_data["Customer"],
                 )
             )
             customer = customer[0].get("internalId") if customer else None
@@ -1284,7 +1291,7 @@ class netsuiteRestV2Sink(BatchSink):
             location = list(
                 filter(
                     lambda x: x["name"] == record.get("location"),
-                    context["reference_data"]["Locations"],
+                    self.reference_data["Locations"],
                 )
             ) 
             location = location[0].get("internalId") if location else None
@@ -1295,7 +1302,7 @@ class netsuiteRestV2Sink(BatchSink):
             subsidiary = list(
                 filter(
                     lambda x: x["name"] == record.get("subsidiary"),
-                    context["reference_data"]["Subsidiaries"],
+                    self.reference_data["Subsidiaries"],
                 )
             ) 
             subsidiary = subsidiary[0].get("internalId") if subsidiary else None
@@ -1311,7 +1318,7 @@ class netsuiteRestV2Sink(BatchSink):
                 product = list(
                     filter(
                         lambda x: x["itemId"] == item["productName"],
-                        context["reference_data"]["Items"],
+                        self.reference_data["Items"],
                     )
                 )
                 product = product[0].get("internalId") if product else None
@@ -1363,7 +1370,7 @@ class netsuiteRestV2Sink(BatchSink):
             currency = list(
                 filter(
                     lambda x: x["symbol"] == currency,
-                    context["reference_data"]["Currencies"],
+                    self.reference_data["Currencies"],
                 )
             )
             currency = currency[0].get("name") if currency else None
@@ -1384,7 +1391,7 @@ class netsuiteRestV2Sink(BatchSink):
             customer = list(
                 filter(
                     lambda x: x["companyName"] == record.get("customerName"),
-                    context["reference_data"]["Customer"],
+                    self.reference_data["Customer"],
                 )
             )
             customer = customer[0].get("internalId") if customer else None
@@ -1397,7 +1404,7 @@ class netsuiteRestV2Sink(BatchSink):
             location = list(
                 filter(
                     lambda x: x["name"] == record.get("location"),
-                    context["reference_data"]["Locations"],
+                    self.reference_data["Locations"],
                 )
             ) 
             location = location[0].get("internalId") if location else None
@@ -1408,7 +1415,7 @@ class netsuiteRestV2Sink(BatchSink):
             subsidiary = list(
                 filter(
                     lambda x: x["name"] == record.get("subsidiary"),
-                    context["reference_data"]["Subsidiaries"],
+                    self.reference_data["Subsidiaries"],
                 )
             ) 
             subsidiary = subsidiary[0].get("internalId") if subsidiary else None
@@ -1421,7 +1428,7 @@ class netsuiteRestV2Sink(BatchSink):
                 product = list(
                     filter(
                         lambda x: x["itemId"] == item["productName"],
-                        context["reference_data"]["Items"],
+                        self.reference_data["Items"],
                     )
                 )
                 product = product[0].get("internalId") if product else None
@@ -1456,7 +1463,7 @@ class netsuiteRestV2Sink(BatchSink):
         return refund_mapping
 
     def process_vendors(self, context, record):
-        vendors = context["reference_data"]["Vendors"]
+        vendors = self.reference_data["Vendors"]
         vendor = None
         if record.get("id"):
             vendor = list(
@@ -1507,7 +1514,7 @@ class netsuiteRestV2Sink(BatchSink):
 
         if record.get("id") or record.get("itemId"):
             match_conditions = [("id", "internalId"), ("id", "itemId"), ("itemId", "itemId"), ]
-            matching_item = next((item for item in context["reference_data"]["Items"] if any(item[netsuite_field] == record.get(payload_field) for (payload_field, netsuite_field) in match_conditions)), None)
+            matching_item = next((item for item in self.reference_data["Items"] if any(item[netsuite_field] == record.get(payload_field) for (payload_field, netsuite_field) in match_conditions)), None)
             if matching_item:
                 payload["id"] = matching_item.get("internalId")
                 payload["itemId"] = matching_item.get("itemId")
@@ -1519,10 +1526,10 @@ class netsuiteRestV2Sink(BatchSink):
         if isinstance(subsidiary, str):
             subsidiary = [subsidiary]
         
-        if context["reference_data"].get("Subsidiaries"):
+        if self.reference_data.get("Subsidiaries"):
             subsidiary_obj = [
                 sub
-                for sub in context["reference_data"].get("Subsidiaries")
+                for sub in self.reference_data.get("Subsidiaries")
                 if sub.get("name") in subsidiary or sub.get("internalId") in subsidiary
             ]
             if subsidiary_obj:
@@ -1543,7 +1550,7 @@ class netsuiteRestV2Sink(BatchSink):
                         income_account.get("accountId"),
                         income_account.get("accountNumber"),
                     ),
-                    context["reference_data"]["Accounts"],
+                    self.reference_data["Accounts"],
                 )
             )
             if account:
@@ -1580,7 +1587,7 @@ class netsuiteRestV2Sink(BatchSink):
 
         if record.get("id") or record.get("itemId"):
             match_conditions = [("id", "internalId"), ("id", "itemId"), ("itemId", "itemId"), ]
-            matching_item = next((item for item in context["reference_data"]["Items"] if any(item[netsuite_field] == record.get(payload_field) for (payload_field, netsuite_field) in match_conditions)), None)
+            matching_item = next((item for item in self.reference_data["Items"] if any(item[netsuite_field] == record.get(payload_field) for (payload_field, netsuite_field) in match_conditions)), None)
             if matching_item:
                 payload["id"] = matching_item.get("internalId")
                 payload["itemId"] = matching_item.get("itemId")
@@ -1596,7 +1603,7 @@ class netsuiteRestV2Sink(BatchSink):
             account = list(
                 filter(
                     lambda x: self.get_account_by_name_id_number(x, accountName, id),
-                    context["reference_data"]["Accounts"],
+                    self.reference_data["Accounts"],
                 )
             )[0]
             payload["cogsAccount"] = {"id": account["internalId"]}
@@ -1611,7 +1618,7 @@ class netsuiteRestV2Sink(BatchSink):
                 account = list(
                     filter(
                         lambda x: self.get_account_by_name_id_number(x, accountName, id),
-                        context["reference_data"]["Accounts"],
+                        self.reference_data["Accounts"],
                     )
                 )[0]
                 payload["incomeAccount"] = {"id": account["internalId"]}
@@ -1635,9 +1642,9 @@ class netsuiteRestV2Sink(BatchSink):
         # Get the NetSuite Vendor Ref
         if record.get("vendorId"):
             purchase_order["entity"] = {"id": record.get("vendorId")}
-        elif context["reference_data"].get("Vendors") and record.get("vendorName"):
+        elif self.reference_data.get("Vendors") and record.get("vendorName"):
             vendor_names = []
-            for c in context["reference_data"]["Vendors"]:
+            for c in self.reference_data["Vendors"]:
                 if "entityId" in c.keys():
                     vendor_names.append(c["entityId"])
             vendor_name = self.get_close_matches(
@@ -1646,7 +1653,7 @@ class netsuiteRestV2Sink(BatchSink):
             if vendor_name:
                 vendor_name = max(vendor_name, key=vendor_name.get)
                 vendor_data = []
-                for c in context["reference_data"]["Vendors"]:
+                for c in self.reference_data["Vendors"]:
                     if c["entityId"] == vendor_name:
                         vendor_data.append(c)
                 if vendor_data:
@@ -1670,10 +1677,10 @@ class netsuiteRestV2Sink(BatchSink):
         location = None
         if record.get("locationId"):
             location = {"id": record["locationId"]}
-        elif context["reference_data"].get("Locations") and record.get("location"):
+        elif self.reference_data.get("Locations") and record.get("location"):
             loc_data = [
                 l
-                for l in context["reference_data"]["Locations"]
+                for l in self.reference_data["Locations"]
                 if l["name"] == record["location"]
             ]
             if loc_data:
@@ -1696,9 +1703,9 @@ class netsuiteRestV2Sink(BatchSink):
             # Get the product Id
             if line.get("product_id"):
                 order_item["item"] = {"id": line.get("product_id")}
-            elif context["reference_data"].get("Items") and line.get("product_name"):
+            elif self.reference_data.get("Items") and line.get("product_name"):
                 product_names = [
-                    c["itemId"] for c in context["reference_data"]["Items"]
+                    c["itemId"] for c in self.reference_data["Items"]
                 ]
                 product_name = self.get_close_matches(
                     line["product_name"], product_names, n=2, cutoff=0.95
@@ -1707,7 +1714,7 @@ class netsuiteRestV2Sink(BatchSink):
                     product_name = max(product_name, key=product_name.get)
                     product_data = [
                         c
-                        for c in context["reference_data"]["Items"]
+                        for c in self.reference_data["Items"]
                         if c["itemId"] == product_name
                     ]
                     if product_data:

--- a/target_netsuite_v2/rest_client.py
+++ b/target_netsuite_v2/rest_client.py
@@ -14,12 +14,6 @@ import xmltodict
 class netsuiteRestV2Sink(HotglueSink):
     """netsuite-v2 target sink class."""
 
-    def _extract_id_from_response_header(self, headers):
-        location = headers.get("Location")
-        #example 'Location': 'https://{ns_account}.suitetalk.api.netsuite.com/services/rest/record/v1/customer/{id}'
-        if not location:
-            return None
-        return location.split("/")[-1]
 
     @property
     def url_account(self) -> str:

--- a/target_netsuite_v2/rest_client.py
+++ b/target_netsuite_v2/rest_client.py
@@ -254,7 +254,7 @@ class netsuiteRestV2Sink(HotglueSink):
             (accountName is not None and x["acctName"] == accountName)
         )
 
-    def process_order(self, context, record):
+    def process_order(self, record):
         sale_order = {}
         items = []
 
@@ -320,7 +320,7 @@ class netsuiteRestV2Sink(HotglueSink):
             sale_order["order_number"] = record.get("order_number")
         return sale_order
 
-    def process_vendor_bill(self, context, record):
+    def process_vendor_bill(self, record):
         vendor_bill = {}
 
         if record.get("vendorBillNumber"):
@@ -535,7 +535,7 @@ class netsuiteRestV2Sink(HotglueSink):
 
         return vendor_bill
 
-    def process_invoice(self, context, record):
+    def process_invoice(self, record):
         invoice = {}
         items = []
         if record.get("invoiceNumber"):
@@ -659,7 +659,7 @@ class netsuiteRestV2Sink(HotglueSink):
         invoice["item"] = {"items": items}
         return invoice
 
-    def invoice_payment(self, context, record):
+    def invoice_payment(self, record):
         raw_record = record.copy()
         invoice_id = record.get("transactionId", record.get("id"))
         url = f"https://{self.url_account}.suitetalk.api.netsuite.com/services/NetSuitePort_2024_2"
@@ -788,7 +788,7 @@ class netsuiteRestV2Sink(HotglueSink):
             "raw_record": raw_record
         }
 
-    def vendor_payment(self, context, record):
+    def vendor_payment(self, record):
         """
         Initialize a Vendor Payment:
         The initialize operation in NetSuite is used to create a new record (in this case, a vendorPayment)
@@ -914,7 +914,7 @@ class netsuiteRestV2Sink(HotglueSink):
             "raw_record": raw_record
         }
 
-    def process_vendor_credit(self, context, record):
+    def process_vendor_credit(self, record):
         # Get the NetSuite Vendor Ref
         vendor_credit = {}
         if record.get("vendorId") or record.get("vendorNum"):
@@ -1170,7 +1170,7 @@ class netsuiteRestV2Sink(HotglueSink):
             raise ConnectionError(res.text)
         return res
 
-    def process_customer(self, context, record):
+    def process_customer(self, record):
         customers = self.reference_data["Customer"]
         subsidiary = record.get("subsidiary")
         sales_rep = record.get("ownerId")
@@ -1267,7 +1267,7 @@ class netsuiteRestV2Sink(HotglueSink):
 
         return customer
 
-    def process_credit_memo(self, context, record):
+    def process_credit_memo(self, record):
         
         if not record.get("customerName") and not record.get("customerId"):
             raise Exception(f"Neither CustomerId nor customerName was provided and it's a required field for credit memo.")
@@ -1379,7 +1379,7 @@ class netsuiteRestV2Sink(HotglueSink):
 
         return credit_memo_mapping
     
-    def process_refund(self, context, record):
+    def process_refund(self, record):
         
         # validate required field currency
         if not record.get("currency"):
@@ -1462,7 +1462,7 @@ class netsuiteRestV2Sink(HotglueSink):
 
         return refund_mapping
 
-    def process_vendors(self, context, record):
+    def process_vendors(self, record):
         vendors = self.reference_data["Vendors"]
         vendor = None
         if record.get("id"):
@@ -1499,7 +1499,7 @@ class netsuiteRestV2Sink(HotglueSink):
 
         return vendor_mapping
     
-    def process_service_sale_item(self, context, record):
+    def process_service_sale_item(self, record):
 
         payload = {
             "displayName": record.get("displayName") or record.get("name"),
@@ -1569,10 +1569,10 @@ class netsuiteRestV2Sink(HotglueSink):
 
         return payload
 
-    def process_item(self, context, record):
+    def process_item(self, record):
 
         if record.get("type", "").lower() == "service for sale":
-            return self.process_service_sale_item(context, record)
+            return self.process_service_sale_item(record)
 
         payload = {
             "displayName": record.get("name"),
@@ -1625,7 +1625,7 @@ class netsuiteRestV2Sink(HotglueSink):
 
         return payload
 
-    def process_purchase_order(self, context, record):
+    def process_purchase_order(self, record):
         purchase_order = {}
         if record.get("order_number"):
             purchase_order["externalId"] = record["order_number"]

--- a/target_netsuite_v2/rest_client.py
+++ b/target_netsuite_v2/rest_client.py
@@ -1,6 +1,6 @@
 """netsuite-v2 target sink class, which handles writing streams."""
 
-from target_hotglue.sinks import HotglueSink
+from hotglue_singer_sdk.target_sdk.client import HotglueSink
 import requests
 from oauthlib import oauth1
 from requests_oauthlib import OAuth1

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -213,8 +213,8 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
                         continue
                     self.logger.info(f"Creating customer subsidiary relationship for customer {id} and subsidiary {relationship.get('subsidiary')}")
                     relationship["entity"] = {"id": id}
-                    response = self.rest_post(url=relationship_url, json=relationship)
-                    self.logger.info(response)
+                    relationship_response = self.rest_post(url=relationship_url, json=relationship)
+                    self.logger.info(relationship_response)
 
 
         elif self.stream_name.lower() in ['item','items']:
@@ -242,7 +242,8 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
                 elif name in ["InvoicePayment", "VendorPayment", "VendorBill"]:
                     record_id = xmltodict.parse(response.text)["soapenv:Envelope"]["soapenv:Body"]["addResponse"]["writeResponse"]["baseRef"]["@internalId"]
                 else:
-                    record_id = self._extract_id_from_response_header(response.headers)
+                    #example 'Location': 'https://{ns_account}.suitetalk.api.netsuite.com/services/rest/record/v1/customer/{id}'
+                    record_id = response.headers["Location"].split("/")[-1] 
             except:
                 raise Exception(f"Internal ID not found for {name if name else self.stream_name.lower()}, response: {response}")
             

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -13,6 +13,29 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
     def name(self) -> str:
         return self.stream_name
 
+    allows_externalid = [
+        "JournalEntries",
+        "journalentries",
+        "JournalEntry",
+        "journalentry",
+        "VendorBill",
+        "vendorbill",
+        "VendorBills",
+        "vendorbills",
+        "PurchaseInvoice",
+        "purchaseinvoices",
+        "PurchaseInvoices",
+        "purchaseinvoice",
+        "Bill",
+        "bill",
+        "Bills",
+        "bills",
+        "PurchaseOrder",
+        "purchaseorder",
+        "PurchaseOrders",
+        "purchaseorders",
+    ]
+
     
     def __init__(
         self,

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -37,7 +37,7 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
             self.logger.info(f"Record is empty for {self.stream_name}")
             return
         if self.stream_name.lower() in ["journalentries", "journalentry"]:
-            journal_entry = self.process_journal_entry(context, record, self.rest_post)
+            journal_entry = self.process_journal_entry(record, self.rest_post)
             # do final validation
             for line in journal_entry.get('lineList', []):
                 for cf in line.get('customFieldList', []):
@@ -47,48 +47,48 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
 
             return journal_entry
         if self.stream_name.lower() in ["customer"]:
-            customer = self.process_customer(context,record)
+            customer = self.process_customer(record)
             return customer
         if self.stream_name.lower() in ["inboundshipment","inboundshipments"]:
-            inbound_shipment = self.process_inbound_shipment(context, record)
+            inbound_shipment = self.process_inbound_shipment(record)
             return inbound_shipment
         elif self.stream_name.lower() in ["customerpayment","customerpayments"]:
-            customer_payment = self.process_customer_payment(context, record)
+            customer_payment = self.process_customer_payment(record)
             return customer_payment
         elif self.stream_name.lower() in ["salesorder","salesorders"]:
-            sale_order = self.process_order(context, record)
+            sale_order = self.process_order(record)
             return sale_order
         elif self.stream_name.lower() in ["invoice", "invoices"]:
-            invoice = self.process_invoice(context, record)
+            invoice = self.process_invoice(record)
             return invoice
         elif self.stream_name.lower() in ["creditmemo","creditmemos"]:
-            credit_memo = self.process_credit_memo(context, record)
+            credit_memo = self.process_credit_memo(record)
             return credit_memo
         elif self.stream_name.lower() in ["refund","refunds"]:
-            refund = self.process_refund(context, record)
+            refund = self.process_refund(record)
             return refund
         elif self.stream_name.lower() in ["vendor","vendors"]:
-            vendor = self.process_vendors(context, record)
+            vendor = self.process_vendors(record)
             return vendor
         elif self.stream_name.lower() in ["vendorbill", "vendorbills", "purchaseinvoices","purchaseinvoice", "bill", "bills"]:
-            vendor_bill = self.process_vendor_bill(context, record)
+            vendor_bill = self.process_vendor_bill(record)
             return vendor_bill
         elif self.stream_name.lower() in ["vendorcredit", "vendorcredits", "apadjustment", "apadjustments"]:
-            vendor_credit = self.process_vendor_credit(context, record)
+            vendor_credit = self.process_vendor_credit(record)
             return vendor_credit
         elif self.stream_name.lower() in ["invoicepayments","invoicepayment"]:
-            invoice_payment = self.invoice_payment(context, record)
+            invoice_payment = self.invoice_payment(record)
             return invoice_payment
         elif self.stream_name.lower() in ["vendorpayments","vendorpayment", "billpayment", "billpayments"]:
-            vendor_payment = self.vendor_payment(context, record)
+            vendor_payment = self.vendor_payment(record)
             return vendor_payment
         elif self.stream_name.lower() in ["PurchaseOrderToVendorBill"]:
             return record
         elif self.stream_name.lower() in ['item','items']:
-            item = self.process_item(context,record)
+            item = self.process_item(record)
             return item
         elif self.stream_name.lower() in ['purchaseorder','purchaseorders']:
-            order = self.process_purchase_order(context,record)
+            order = self.process_purchase_order(record)
             return order
 
     def upsert_record(self, record, context):

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -95,7 +95,7 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
     def upsert_record(self, record, context):
         """Write out any prepped records and return once fully written."""
         self.logger.info(f"Posting data for entity {self.stream_name}")
-        name = None
+        name = ""
         if self.stream_name.lower() in ["journalentries", "journalentry", "customerpayment", "customerpayments"]:
             if self.stream_name.lower() in ["journalentries", "journalentry"]:
                 name = "JournalEntry"
@@ -241,10 +241,11 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
                     record_id = response["internalId"]
                 elif name in ["InvoicePayment", "VendorPayment", "VendorBill"]:
                     record_id = xmltodict.parse(response.text)["soapenv:Envelope"]["soapenv:Body"]["addResponse"]["writeResponse"]["baseRef"]["@internalId"]
+                else:
+                    record_id = self._extract_id_from_response_header(response.headers)
             except:
-                raise Exception(f"Internal ID not found for {name}, response: {response}")
-            else:
-                record_id = self._extract_id_from_response_header(response.headers)
+                raise Exception(f"Internal ID not found for {name if name else self.stream_name.lower()}, response: {response}")
+            
             return record_id, True, {}
         else:
             return None, True, {}

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -94,7 +94,8 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
     def upsert_record(self, record, context):
         """Write out any prepped records and return once fully written."""
         self.logger.info(f"Posting data for entity {self.stream_name}")
-        if self.stream_name.lower() in ["journalentries", "journalentry", "customerpayment"]:
+        name = None
+        if self.stream_name.lower() in ["journalentries", "journalentry", "customerpayment", "customerpayments"]:
             if self.stream_name.lower() in ["journalentries", "journalentry"]:
                 name = "JournalEntry"
             else:
@@ -182,6 +183,7 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
                 response = self.rest_patch(url=url, json=record)
             else:
                 response = self.ns_client.entities["InboundShipment"].post(record)
+                name = "InboundShipment"
 
             self.logger.info(response)
 
@@ -230,7 +232,13 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
             response = self.rest_post(url=url,json=record)
 
         if response:
-            record_id = self._extract_id_from_response_header(response.headers)
+            if name in ["JournalEntry", "CustomerPayment", "InboundShipment"]:
+                try:    
+                    record_id = response["internalId"]
+                except:
+                    raise Exception(f"Internal ID not found for {name}, response: {response}")
+            else:
+                record_id = self._extract_id_from_response_header(response.headers)
             return record_id, True, {}
         else:
             return None, True, {}

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -1,5 +1,6 @@
 """netsuite-v2 target sink class, which handles writing streams."""
 
+from singer_sdk.plugin_base import PluginBase
 from target_netsuite_v2.soap_client import netsuiteSoapV2Sink
 from target_netsuite_v2.rest_client import netsuiteRestV2Sink
 
@@ -7,31 +8,30 @@ from target_netsuite_v2.rest_client import netsuiteRestV2Sink
 class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
     """netsuite-v2 target sink class."""
 
-    def start_batch(self, context: dict) -> None:
-        """Start a batch."""
+    @property
+    def name(self) -> str:
+        return self.stream_name
+
+    
+    def __init__(
+        self,
+        target: PluginBase,
+        stream_name: str,
+        schema,
+        key_properties,
+    ) -> None:
+        self._state = dict(target._state)
+        self._target = target
+
+        super().__init__(target, stream_name, schema, key_properties)
 
         self.get_ns_client()
-        context["reference_data"] = self.get_reference_data()
-        context["reference_data"]["CustomFields"] = self._fetch_all_custom_fields()
-        context["reference_data"]["CustomLists"] = self._fetch_custom_lists()
-        context["reference_data"]["CustomRecordTypes"] = self._fetch_custom_record_types()
-        context["JournalEntry"] = []
-        context["SalesOrder"] = []
-        context["Invoice"] = []
-        context["InvoicePayment"] = []
-        context["vendorBill"] = []
-        context["vendorCredit"] = []
-        context["VendorPayment"] = []
-        context["Vendor"] = []
-        context["PurchaseOrderToVendorBill"] = []
-        context["InboundShipment"] = []
-        context['CreditMemo'] = []
-        context['Customer'] = []
-        context['Items'] = []
-        context['PurchaseOrder'] = []
-        context['Refund'] = []
+        self.reference_data = self.get_reference_data()
+        self.reference_data["CustomFields"] = self._fetch_all_custom_fields()
+        self.reference_data["CustomLists"] = self._fetch_custom_lists()
+        self.reference_data["CustomRecordTypes"] = self._fetch_custom_record_types()
 
-    def process_record(self, record: dict, context: dict) -> None:
+    def preprocess_record(self, record: dict, context: dict) -> dict | None:
         """Process the record."""
         if not record:
             self.logger.info(f"Record is empty for {self.stream_name}")
@@ -45,53 +45,53 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
                     if not self.check_custom_field(script_id):
                         raise Exception(f"Error parsing custom field, scriptid '{script_id}' is not valid.")
 
-            context["JournalEntry"].append(journal_entry)
+            return journal_entry
         if self.stream_name.lower() in ["customer"]:
             customer = self.process_customer(context,record)
-            context["Customer"].append(customer)
+            return customer
         if self.stream_name.lower() in ["inboundshipment","inboundshipments"]:
             inbound_shipment = self.process_inbound_shipment(context, record)
-            context["InboundShipment"].append(inbound_shipment)
+            return inbound_shipment
         elif self.stream_name.lower() in ["customerpayment","customerpayments"]:
             customer_payment = self.process_customer_payment(context, record)
-            context["CustomerPayment"].append(customer_payment)
+            return customer_payment
         elif self.stream_name.lower() in ["salesorder","salesorders"]:
             sale_order = self.process_order(context, record)
-            context["SalesOrder"].append(sale_order)
+            return sale_order
         elif self.stream_name.lower() in ["invoice", "invoices"]:
             invoice = self.process_invoice(context, record)
-            context["Invoice"].append(invoice)
+            return invoice
         elif self.stream_name.lower() in ["creditmemo","creditmemos"]:
             credit_memo = self.process_credit_memo(context, record)
-            context["CreditMemo"].append(credit_memo)
+            return credit_memo
         elif self.stream_name.lower() in ["refund","refunds"]:
             refund = self.process_refund(context, record)
-            context["Refund"].append(refund)
+            return refund
         elif self.stream_name.lower() in ["vendor","vendors"]:
             vendor = self.process_vendors(context, record)
-            context["Vendor"].append(vendor)
+            return vendor
         elif self.stream_name.lower() in ["vendorbill", "vendorbills", "purchaseinvoices","purchaseinvoice", "bill", "bills"]:
             vendor_bill = self.process_vendor_bill(context, record)
-            context["vendorBill"].append(vendor_bill)
+            return vendor_bill
         elif self.stream_name.lower() in ["vendorcredit", "vendorcredits", "apadjustment", "apadjustments"]:
             vendor_credit = self.process_vendor_credit(context, record)
-            context["vendorCredit"].append(vendor_credit)
+            return vendor_credit
         elif self.stream_name.lower() in ["invoicepayments","invoicepayment"]:
             invoice_payment = self.invoice_payment(context, record)
-            context["InvoicePayment"].append(invoice_payment)
+            return invoice_payment
         elif self.stream_name.lower() in ["vendorpayments","vendorpayment", "billpayment", "billpayments"]:
             vendor_payment = self.vendor_payment(context, record)
-            context["VendorPayment"].append(vendor_payment)
+            return vendor_payment
         elif self.stream_name.lower() in ["PurchaseOrderToVendorBill"]:
-            context["PurchaseOrderToVendorBill"].append(record)
+            return record
         elif self.stream_name.lower() in ['item','items']:
             item = self.process_item(context,record)
-            context["Items"].append(item)
+            return item
         elif self.stream_name.lower() in ['purchaseorder','purchaseorders']:
             order = self.process_purchase_order(context,record)
-            context['PurchaseOrder'].append(order)
+            return order
 
-    def process_batch(self, context: dict) -> None:
+    def upsert_record(self, record, context):
         """Write out any prepped records and return once fully written."""
         self.logger.info(f"Posting data for entity {self.stream_name}")
         if self.stream_name.lower() in ["journalentries", "journalentry", "customerpayment"]:
@@ -99,142 +99,136 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
                 name = "JournalEntry"
             else:
                 name = "CustomerPayment"
-            for record in context.get(name, []):
-                response = self.ns_client.entities[name].post(record)
-                self.logger.info(response)
+            
+            response = self.ns_client.entities[name].post(record)
+            self.logger.info(response)
         elif self.stream_name.lower() in ["salesorder","salesorders"]:
             url = f"{self.url_base}salesOrder"
-            for record in context.get("SalesOrder", []):
-                if record.get("order_number") is None:
-                    response = self.rest_post(url=url, json=record)
-                else:
-                    self.logger.info(f"Updating Order: {record.get('order_number')}")
-                    response = self.rest_patch(url=f"{url}/{record.pop('order_number')}", json=record)
+            
+            if record.get("order_number") is None:
+                response = self.rest_post(url=url, json=record)
+            else:
+                self.logger.info(f"Updating Order: {record.get('order_number')}")
+                response = self.rest_patch(url=f"{url}/{record.pop('order_number')}", json=record)
         elif self.stream_name.lower() in ["invoice", "invoices"]:
             url = f"{self.url_base}invoice"
-            for record in context.get("Invoice", []):
-                # If there's a tranid, we want to check if the invoice already exists, and if so upsert
-                if record.get("tranId"):
-                    existing = self.rest_get(url=f"{url}?q=tranid IS {record['tranId']}").json()
-                    if existing.get("count") > 0:
-                        # we need to use the real netsuite id to do the upsert
-                        inv_id = existing["items"][0]["id"]
-                        
-                        # Since this is an eisting invoice, we delete the item from the invoice.
-                        # This is done to work around the where items in netsuite are getting duplicated on update.
-                        if 'item' in record:
-                            del record['item']
-                        # NetSuite does not allow updating currency on existing transactions
-                        # see: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/bridgehead_N1398658.html
-                        if 'currency' in record:
-                            del record['currency']
+            
+            # If there's a tranid, we want to check if the invoice already exists, and if so upsert
+            if record.get("tranId"):
+                existing = self.rest_get(url=f"{url}?q=tranid IS {record['tranId']}").json()
+                if existing.get("count") > 0:
+                    # we need to use the real netsuite id to do the upsert
+                    inv_id = existing["items"][0]["id"]
+                    
+                    # Since this is an eisting invoice, we delete the item from the invoice.
+                    # This is done to work around the where items in netsuite are getting duplicated on update.
+                    if 'item' in record:
+                        del record['item']
+                    # NetSuite does not allow updating currency on existing transactions
+                    # see: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/bridgehead_N1398658.html
+                    if 'currency' in record:
+                        del record['currency']
 
-                        response = self.rest_patch(url=f"{url}/{inv_id}", json=record)
-                        continue
+                    response = self.rest_patch(url=f"{url}/{inv_id}", json=record)
 
-                response = self.rest_post(url=url, json=record)
+            response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["creditmemo","creditmemos"]:
             url = f"{self.url_base}creditMemo"
-            for record in context.get("CreditMemo", []):
-                id = record.pop("id", None)
-                if id:
-                    self.logger.info(f"Updating credit memo: {id}")
-                    response = self.rest_patch(url=f"{url}/{id}", json=record)
-                else:
-                    response = self.rest_post(url=url, json=record)
+            id = record.pop("id", None)
+            if id:
+                self.logger.info(f"Updating credit memo: {id}")
+                response = self.rest_patch(url=f"{url}/{id}", json=record)
+            else:
+                response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["refund","refunds"]:
             url = f"{self.url_base}cashRefund"
-            for record in context.get("Refund", []):
-                id = record.pop("id", None)
-                if id:
-                    self.logger.info(f"Updating refund: {id}")
-                    response = self.rest_patch(url=f"{url}/{id}", json=record)
-                else:
-                    response = self.rest_post(url=url, json=record)
+            
+            id = record.pop("id", None)
+            if id:
+                self.logger.info(f"Updating refund: {id}")
+                response = self.rest_patch(url=f"{url}/{id}", json=record)
+            else:
+                response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["vendor","vendors"]:
             url = f"{self.url_base}vendor"
-            for record in context.get("Vendor", []):
-                if record.get("internalId"):
-                    response = self.rest_patch(url=f"{url}/{record.pop('internalId')}", json={
-                        key: value
-                        for key, value in record.items()
-                        if value is not None
-                    })
-                else:
-                    response = self.rest_post(url=url, json=record)
+            if record.get("internalId"):
+                response = self.rest_patch(url=f"{url}/{record.pop('internalId')}", json={
+                    key: value
+                    for key, value in record.items()
+                    if value is not None
+                })
+            else:
+                response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["vendorbill","vendorbills","bill","bills","purchaseinvoices","purchaseinvoice"]:
             url = f"{self.url_base}vendorbill"
-            for record in context.get("vendorBill", []):
-                response = self.rest_post(url=url, json=record)
+            response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["vendorcredit","vendorcredits","apadjustment","apadjustments"]:
             url = f"{self.url_base}vendorCredit"
-            for record in context.get("vendorCredit", []):
-                response = self.rest_post(url=url, json=record)
+            response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["invoicepayment","invoicepayments"]:
-            for record in context.get("InvoicePayment", []):
-                response = self.push_payments(record)
+            response = self.push_payments(record)
         elif self.stream_name.lower() in ["vendorpayment","vendorpayments", "billpayment", "billpayments"]:
-            for record in context.get("VendorPayment", []):
-                response = self.push_vendor_payments(record)
+            response = self.push_vendor_payments(record)
         elif self.stream_name in ["PurchaseOrderToVendorBill"]:
-            for record in context.get("PurchaseOrderToVendorBill", []):
-                response = self.po_to_vb(record)
+            response = self.po_to_vb(record)
         elif self.stream_name.lower() in ['inboundshipment','inboundshipments']:
-            for record in context.get("InboundShipment", []):
-                if record.get("id"):
-                    endpoint="inboundShipment"
-                    endpoint = endpoint + "/{id}"
-                    endpoint = endpoint.format(id=record.pop("id"))
-                    url = f"{self.url_base}{endpoint}"
-                    response = self.rest_patch(url=url, json=record)
-                else:
-                    response = self.ns_client.entities["InboundShipment"].post(record)
+            if record.get("id"):
+                endpoint="inboundShipment"
+                endpoint = endpoint + "/{id}"
+                endpoint = endpoint.format(id=record.pop("id"))
+                url = f"{self.url_base}{endpoint}"
+                response = self.rest_patch(url=url, json=record)
+            else:
+                response = self.ns_client.entities["InboundShipment"].post(record)
 
-                self.logger.info(response)
+            self.logger.info(response)
 
         elif self.stream_name.lower() in ['customers','customer']:
             url = f"{self.url_base}{self.stream_name.lower()}"
 
-            for record in context.get("Customer", []):
-                customer_subsidiary_relationships = record.pop("customerSubsidiaryRelationships", None)
-                id = record.pop("id", None)
-                if id:
-                    response = self.rest_patch(url=f"{url}/{id}", json=record)
-                    self.logger.info(f"Customer with id '{id}' updated")
-                else:
-                    response = self.rest_post(url=url, json=record)
-                    id = response.headers["Location"].split("/")[-1]
-                    self.logger.info(f"Customer with id '{id}' created")
-                # add additional subsidiaries to the customer
-                if customer_subsidiary_relationships:
-                    relationship_url = f"{self.url_base}customerSubsidiaryRelationship"
-                    existing_relationship_objects = self.get_customer_subsidiary_relationships(id)
-                    subsidiaries_already_linked = [relationship.get('subsidiary') for relationship in existing_relationship_objects]
-                    for relationship in customer_subsidiary_relationships:
-                        if relationship.get('subsidiary', {}).get('id') in subsidiaries_already_linked:
-                            continue
-                        self.logger.info(f"Creating customer subsidiary relationship for customer {id} and subsidiary {relationship.get('subsidiary')}")
-                        relationship["entity"] = {"id": id}
-                        response = self.rest_post(url=relationship_url, json=relationship)
-                        self.logger.info(response)
+            customer_subsidiary_relationships = record.pop("customerSubsidiaryRelationships", None)
+            id = record.pop("id", None)
+            if id:
+                response = self.rest_patch(url=f"{url}/{id}", json=record)
+                self.logger.info(f"Customer with id '{id}' updated")
+            else:
+                response = self.rest_post(url=url, json=record)
+                id = response.headers["Location"].split("/")[-1]
+                self.logger.info(f"Customer with id '{id}' created")
+            # add additional subsidiaries to the customer
+            if customer_subsidiary_relationships:
+                relationship_url = f"{self.url_base}customerSubsidiaryRelationship"
+                existing_relationship_objects = self.get_customer_subsidiary_relationships(id)
+                subsidiaries_already_linked = [relationship.get('subsidiary') for relationship in existing_relationship_objects]
+                for relationship in customer_subsidiary_relationships:
+                    if relationship.get('subsidiary', {}).get('id') in subsidiaries_already_linked:
+                        continue
+                    self.logger.info(f"Creating customer subsidiary relationship for customer {id} and subsidiary {relationship.get('subsidiary')}")
+                    relationship["entity"] = {"id": id}
+                    response = self.rest_post(url=relationship_url, json=relationship)
+                    self.logger.info(response)
 
 
         elif self.stream_name.lower() in ['item','items']:
             url = f"{self.url_base}"
-            for record in context.get("Items",[]):
-                item_type = record.pop("type", None)
-                if item_type == "service for sale":
-                    url = f"{self.url_base}serviceSaleItem"
-                else:
-                    url = f"{self.url_base}inventoryItem"
+            item_type = record.pop("type", None)
+            if item_type == "service for sale":
+                url = f"{self.url_base}serviceSaleItem"
+            else:
+                url = f"{self.url_base}inventoryItem"
 
-                if record.get("id"):
-                    patch_url = url + "/{id}"
-                    patch_url = patch_url.format(id=record.pop("id"))
-                    response = self.rest_patch(url=patch_url,json=record)
-                else:
-                    response = self.rest_post(url=url,json=record)
+            if record.get("id"):
+                patch_url = url + "/{id}"
+                patch_url = patch_url.format(id=record.pop("id"))
+                response = self.rest_patch(url=patch_url,json=record)
+            else:
+                response = self.rest_post(url=url,json=record)
         elif self.stream_name.lower() in ['purchaseorder','purchaseorders']:
             url = f"{self.url_base}purchaseOrder"
-            for record in context.get("PurchaseOrder",[]):
-                response = self.rest_post(url=url,json=record)
+            response = self.rest_post(url=url,json=record)
+
+        if response:
+            record_id = self._extract_id_from_response_header(response.headers)
+            return record_id, True, {}
+        else:
+            return None, True, {}

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -1,6 +1,6 @@
 """netsuite-v2 target sink class, which handles writing streams."""
 
-from singer_sdk.plugin_base import PluginBase
+from hotglue_singer_sdk.plugin_base import PluginBase
 from target_netsuite_v2.soap_client import netsuiteSoapV2Sink
 from target_netsuite_v2.rest_client import netsuiteRestV2Sink
 import xmltodict

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -112,11 +112,12 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
                 response = self.rest_patch(url=f"{url}/{record.pop('order_number')}", json=record)
         elif self.stream_name.lower() in ["invoice", "invoices"]:
             url = f"{self.url_base}invoice"
-            
+            invoice_already_exists = False
             # If there's a tranid, we want to check if the invoice already exists, and if so upsert
             if record.get("tranId"):
                 existing = self.rest_get(url=f"{url}?q=tranid IS {record['tranId']}").json()
                 if existing.get("count") > 0:
+                    invoice_already_exists = True
                     # we need to use the real netsuite id to do the upsert
                     inv_id = existing["items"][0]["id"]
                     
@@ -131,7 +132,8 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
 
                     response = self.rest_patch(url=f"{url}/{inv_id}", json=record)
 
-            response = self.rest_post(url=url, json=record)
+            if not invoice_already_exists:
+                response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["creditmemo","creditmemos"]:
             url = f"{self.url_base}creditMemo"
             id = record.pop("id", None)

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -3,6 +3,7 @@
 from singer_sdk.plugin_base import PluginBase
 from target_netsuite_v2.soap_client import netsuiteSoapV2Sink
 from target_netsuite_v2.rest_client import netsuiteRestV2Sink
+import xmltodict
 
 
 class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
@@ -170,10 +171,13 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
             response = self.rest_post(url=url, json=record)
         elif self.stream_name.lower() in ["invoicepayment","invoicepayments"]:
             response = self.push_payments(record)
+            name = "InvoicePayment"
         elif self.stream_name.lower() in ["vendorpayment","vendorpayments", "billpayment", "billpayments"]:
             response = self.push_vendor_payments(record)
+            name = "VendorPayment"
         elif self.stream_name in ["PurchaseOrderToVendorBill"]:
             response = self.po_to_vb(record)
+            name = "VendorBill"
         elif self.stream_name.lower() in ['inboundshipment','inboundshipments']:
             if record.get("id"):
                 endpoint="inboundShipment"
@@ -232,11 +236,13 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
             response = self.rest_post(url=url,json=record)
 
         if response:
-            if name in ["JournalEntry", "CustomerPayment", "InboundShipment"]:
-                try:    
+            try:
+                if name in ["JournalEntry", "CustomerPayment", "InboundShipment"]:
                     record_id = response["internalId"]
-                except:
-                    raise Exception(f"Internal ID not found for {name}, response: {response}")
+                elif name in ["InvoicePayment", "VendorPayment", "VendorBill"]:
+                    record_id = xmltodict.parse(response.text)["soapenv:Envelope"]["soapenv:Body"]["addResponse"]["writeResponse"]["baseRef"]["@internalId"]
+            except:
+                raise Exception(f"Internal ID not found for {name}, response: {response}")
             else:
                 record_id = self._extract_id_from_response_header(response.headers)
             return record_id, True, {}

--- a/target_netsuite_v2/soap_client.py
+++ b/target_netsuite_v2/soap_client.py
@@ -1,6 +1,6 @@
 """netsuite-v2 target sink class, which handles writing streams."""
 
-from target_hotglue.sinks import HotglueSink
+from hotglue_singer_sdk.target_sdk.client import HotglueSink
 from target_netsuite_v2.netsuite import NetSuite
 from target_netsuite_v2.constants import STANDARD_NETSUITE_OBJECTS_MAP, STANDARD_NETSUITE_OBJECTS_SELECT_MAP
 from netsuitesdk.internal.exceptions import NetSuiteRequestError

--- a/target_netsuite_v2/soap_client.py
+++ b/target_netsuite_v2/soap_client.py
@@ -1,6 +1,6 @@
 """netsuite-v2 target sink class, which handles writing streams."""
 
-from singer_sdk.sinks import BatchSink
+from target_hotglue.sinks import HotglueSink
 from target_netsuite_v2.netsuite import NetSuite
 from target_netsuite_v2.constants import STANDARD_NETSUITE_OBJECTS_MAP, STANDARD_NETSUITE_OBJECTS_SELECT_MAP
 from netsuitesdk.internal.exceptions import NetSuiteRequestError
@@ -12,7 +12,7 @@ from heapq import nlargest as _nlargest
 from pendulum import parse
 from datetime import datetime
 
-class netsuiteSoapV2Sink(BatchSink):
+class netsuiteSoapV2Sink(HotglueSink):
     """netsuite-v2 target sink class."""
 
     def get_close_matches(self, word, possibilities, n=20, cutoff=0.7):
@@ -119,10 +119,10 @@ class netsuiteSoapV2Sink(BatchSink):
             fieldValueTypeRecordName = custom_field.get("fieldValueTypeRecordName")
             if fieldValueTypeRecordName in STANDARD_NETSUITE_OBJECTS_MAP:
                 table_name = STANDARD_NETSUITE_OBJECTS_MAP[fieldValueTypeRecordName]
-            elif fieldValueTypeRecordName in context["reference_data"]["CustomLists"]:
-                table_name = context["reference_data"]["CustomLists"][fieldValueTypeRecordName]["scriptid"]
-            elif fieldValueTypeRecordName in context["reference_data"]["CustomRecordTypes"]:
-                table_name = context["reference_data"]["CustomRecordTypes"][fieldValueTypeRecordName]["scriptid"]
+            elif fieldValueTypeRecordName in self.reference_data["CustomLists"]:
+                table_name = self.reference_data["CustomLists"][fieldValueTypeRecordName]["scriptid"]
+            elif fieldValueTypeRecordName in self.reference_data["CustomRecordTypes"]:
+                table_name = self.reference_data["CustomRecordTypes"][fieldValueTypeRecordName]["scriptid"]
             else:
                 # Not a netsuite object, so we can't fetch the id, just return the value as is
                 return "Select", value
@@ -240,14 +240,14 @@ class netsuiteSoapV2Sink(BatchSink):
         for line in record.get("journalLines", record.get("lines", [])):
             journal_entry_line = dict()
 
-            if context["reference_data"].get("Accounts"):
+            if self.reference_data.get("Accounts"):
                 acct_data = None
                 if line.get("accountId"):
-                    acct_data = [a for a in context["reference_data"]["Accounts"] if a["internalId"] == line["accountId"]]
+                    acct_data = [a for a in self.reference_data["Accounts"] if a["internalId"] == line["accountId"]]
                 
                 elif line.get("accountNumber") and not line.get("accountId"):
                     acct_num = str(line["accountNumber"])
-                    acct_data = [a for a in context["reference_data"]["Accounts"] if a["acctNumber"] == acct_num]
+                    acct_data = [a for a in self.reference_data["Accounts"] if a["acctNumber"] == acct_num]
                 
                 if not acct_data:
                     raise Exception(f"AccountId '{line.get('accountId')}' and/or accountNumber {line.get('accountNumber')} were not provided or not valid.")
@@ -285,12 +285,12 @@ class netsuiteSoapV2Sink(BatchSink):
                 raise Exception("We failed to fetch Accounts from NetSuite. Please validate permissions.")
 
             # Get the NetSuite Class Ref
-            if context["reference_data"].get("Classifications") and line.get("className"):
-                class_names = [c["name"] for c in context["reference_data"]["Classifications"]]
+            if self.reference_data.get("Classifications") and line.get("className"):
+                class_names = [c["name"] for c in self.reference_data["Classifications"]]
                 class_name = self.get_close_matches(line["className"], class_names)
                 if class_name:
                     class_name = max(class_name, key=class_name.get)
-                    class_data = [c for c in context["reference_data"]["Classifications"] if c["name"]==class_name]
+                    class_data = [c for c in self.reference_data["Classifications"] if c["name"]==class_name]
                     if class_data:
                         class_data = class_data[0]
                         journal_entry_line["class"] = {
@@ -301,18 +301,18 @@ class netsuiteSoapV2Sink(BatchSink):
 
             # Get the NetSuite Department Ref
             department_name = line.get("departmentName") or line.get("department")
-            if context["reference_data"].get("Departments") and department_name:
+            if self.reference_data.get("Departments") and department_name:
                 dept_data = []
                 # look department name by fully qualified name
-                dept_data = self.get_by_fully_qualified_name(department_name, context["reference_data"]["Departments"])
+                dept_data = self.get_by_fully_qualified_name(department_name, self.reference_data["Departments"])
                 
                 # look department name by name
                 if not dept_data:
-                    dept_names = [d["name"] for d in context["reference_data"]["Departments"]]
+                    dept_names = [d["name"] for d in self.reference_data["Departments"]]
                     dept_name = self.get_close_matches(department_name, dept_names)
                     if dept_name:
                         dept_name = max(dept_name, key=dept_name.get)
-                        dept_data = [d for d in context["reference_data"]["Departments"] if d["name"] == dept_name]
+                        dept_data = [d for d in self.reference_data["Departments"] if d["name"] == dept_name]
 
                 if dept_data:
                     dept_data = dept_data[0]
@@ -326,8 +326,8 @@ class netsuiteSoapV2Sink(BatchSink):
             location_name = line.get("locationName") or line.get("location")
             if line.get("locationId"):
                 journal_entry_line["location"] = {"internalId": line.get("locationId")}
-            elif context["reference_data"].get("Locations") and location_name:
-                loc_data = [l for l in context["reference_data"]["Locations"] if l["name"] == location_name]
+            elif self.reference_data.get("Locations") and location_name:
+                loc_data = [l for l in self.reference_data["Locations"] if l["name"] == location_name]
                 if loc_data:
                     loc_data = loc_data[0]
                     journal_entry_line["location"] = {
@@ -337,17 +337,17 @@ class netsuiteSoapV2Sink(BatchSink):
                     }
 
             # Get the NetSuite Customer Ref
-            if context["reference_data"].get("Customer"):
+            if self.reference_data.get("Customer"):
                 customer_data = []
                 if line.get("customerId"):
-                    customer_data = [c for c in context["reference_data"]["Customer"] if c["internalId"] == line["customerId"]]
+                    customer_data = [c for c in self.reference_data["Customer"] if c["internalId"] == line["customerId"]]
                 if line.get("customerName") and not customer_data:
                     # look customer by entityId
-                    customer_data = [c for c in context["reference_data"]["Customer"] if c["entityId"] == line["customerName"]]
+                    customer_data = [c for c in self.reference_data["Customer"] if c["entityId"] == line["customerName"]]
                     # look for equal or similar customer name
                     if not customer_data:
                         customer_names = []
-                        for c in context["reference_data"]["Customer"]:
+                        for c in self.reference_data["Customer"]:
                             if "name" in c.keys():
                                 if c["name"]:
                                     customer_names.append(c["name"])
@@ -358,7 +358,7 @@ class netsuiteSoapV2Sink(BatchSink):
                         if customer_name:
                             customer_name = max(customer_name, key=customer_name.get)
                             customer_data = []
-                            for c in context["reference_data"]["Customer"]:
+                            for c in self.reference_data["Customer"]:
                                 if "name" in c.keys():
                                     if c["name"] == customer_name:
                                         customer_data.append(c)
@@ -417,12 +417,12 @@ class netsuiteSoapV2Sink(BatchSink):
             line_items.append(journal_entry_line)
 
         # Get the currency ID
-        if record.get("currency") and not context["reference_data"].get("Currencies"):
+        if record.get("currency") and not self.reference_data.get("Currencies"):
             raise Exception("A currency was provided in the payload, but we failed to fetch Currencies from NetSuite. Please validate permissions.")
 
-        if context["reference_data"].get("Currencies") and record.get("currency"):
+        if self.reference_data.get("Currencies") and record.get("currency"):
             currency_data = [
-                c for c in context["reference_data"]["Currencies"] if c["symbol"] == record["currency"]
+                c for c in self.reference_data["Currencies"] if c["symbol"] == record["currency"]
                 ]
             if currency_data:
                 currency_data = currency_data[0]
@@ -497,9 +497,9 @@ class netsuiteSoapV2Sink(BatchSink):
 
     def process_customer_payment(self, context, record):
         # Get the currency ID
-        if context["reference_data"].get("Currencies") and record.get("currency"):
+        if self.reference_data.get("Currencies") and record.get("currency"):
             currency_data = [
-                c for c in context["reference_data"]["Currencies"] if c["symbol"] == record["currency"]
+                c for c in self.reference_data["Currencies"] if c["symbol"] == record["currency"]
                 ]
             if currency_data:
                 currency_data = currency_data[0]

--- a/target_netsuite_v2/soap_client.py
+++ b/target_netsuite_v2/soap_client.py
@@ -93,7 +93,7 @@ class netsuiteSoapV2Sink(HotglueSink):
                 return [record]
         return None
 
-    def _get_custom_field_type_and_value(self, script_id, value, context, rest_post_method):
+    def _get_custom_field_type_and_value(self, script_id, value, rest_post_method):
         """
         Get custom field type from reference data.
         Returns the mapped field type or 'String' as default.
@@ -107,7 +107,7 @@ class netsuiteSoapV2Sink(HotglueSink):
             "Time Of Day": "Time",
             "List/Record": "Select"
         }
-        custom_fields = context.get("reference_data", {}).get("CustomFields", {})
+        custom_fields = self.reference_data.get("CustomFields", {})
         custom_field = custom_fields.get(script_id.upper())
         
         if not custom_field:
@@ -211,12 +211,12 @@ class netsuiteSoapV2Sink(HotglueSink):
 
         return reference_data
 
-    def _lookup_subsidiary(self, subsidiary_name, context):
+    def _lookup_subsidiary(self, subsidiary_name):
         """Look up a subsidiary by name from reference data.
 
         Returns a subsidiary ref dict on match, or None if not found.
         """
-        subsidiaries_ref = context.get("reference_data", {}).get("Subsidiaries") or []
+        subsidiaries_ref = self.reference_data.get("Subsidiaries") or []
         if not subsidiaries_ref:
             return None
 
@@ -234,7 +234,7 @@ class netsuiteSoapV2Sink(HotglueSink):
             "type": None,
         }
 
-    def process_journal_entry(self, context, record, rest_post_method):
+    def process_journal_entry(self, record, rest_post_method):
         subsidiaries = {}
         line_items = []
         for line in record.get("journalLines", record.get("lines", [])):
@@ -265,7 +265,7 @@ class netsuiteSoapV2Sink(HotglueSink):
                 if subsidiary_internal_id:
                     subsidiary = dict(name=None, internalId=subsidiary_internal_id, externalId=None, type=None)
                 elif line.get("subsidiaryName"):
-                    subsidiary = self._lookup_subsidiary(line["subsidiaryName"], context)
+                    subsidiary = self._lookup_subsidiary(line["subsidiaryName"])
                     if not subsidiary:
                         raise Exception(f"Subsidiary with name '{line['subsidiaryName']}' was not found.")
                 else:
@@ -407,7 +407,7 @@ class netsuiteSoapV2Sink(HotglueSink):
                     # Get field type from reference data
                     field_type = entry.get("type")
                     if not field_type:
-                        field_type, value = self._get_custom_field_type_and_value(ns_id, value, context, rest_post_method)
+                        field_type, value = self._get_custom_field_type_and_value(ns_id, value, rest_post_method)
                     
                     custom_field_values.append({"type": field_type, "scriptId": ns_id, "value": value})
 
@@ -440,7 +440,7 @@ class netsuiteSoapV2Sink(HotglueSink):
         if record_subsidiary_internal_id:
             subsidiary = {"internalId": record_subsidiary_internal_id}
         elif record.get("subsidiaryName"):
-            subsidiary = self._lookup_subsidiary(record["subsidiaryName"], context)
+            subsidiary = self._lookup_subsidiary(record["subsidiaryName"])
             if not subsidiary:
                 raise Exception(f"Subsidiary with name '{record['subsidiaryName']}' was not found.")
         elif len(subsidiaries)>1:
@@ -487,7 +487,7 @@ class netsuiteSoapV2Sink(HotglueSink):
                 # Get field type from reference data
                 field_type = entry.get("type")
                 if not field_type:
-                    field_type, value = self._get_custom_field_type_and_value(ns_id, value, context, rest_post_method)
+                    field_type, value = self._get_custom_field_type_and_value(ns_id, value, rest_post_method)
                 
                 record_custom_fields.append({"type": field_type, "scriptId": ns_id, "value": value})
         if record_custom_fields:
@@ -495,7 +495,7 @@ class netsuiteSoapV2Sink(HotglueSink):
 
         return journal_entry
 
-    def process_customer_payment(self, context, record):
+    def process_customer_payment(self, record):
         # Get the currency ID
         if self.reference_data.get("Currencies") and record.get("currency"):
             currency_data = [
@@ -529,7 +529,7 @@ class netsuiteSoapV2Sink(HotglueSink):
         return journal_entry
 
 
-    def process_inbound_shipment(self, context, record):
+    def process_inbound_shipment(self, record):
         inbound_shipment = record
         inbound_shipment["internalId"] = record["id"]
 

--- a/target_netsuite_v2/target.py
+++ b/target_netsuite_v2/target.py
@@ -1,7 +1,7 @@
 """netsuite-v2 target class."""
 
-from singer_sdk import typing as th
-from target_hotglue.target import TargetHotglue
+from hotglue_singer_sdk import typing as th
+from hotglue_singer_sdk.target_sdk.target import TargetHotglue
 
 from target_netsuite_v2.sinks import (
     netsuiteV2Sink,

--- a/target_netsuite_v2/target.py
+++ b/target_netsuite_v2/target.py
@@ -1,14 +1,14 @@
 """netsuite-v2 target class."""
 
-from singer_sdk.target_base import Target
 from singer_sdk import typing as th
+from target_hotglue.target import TargetHotglue
 
 from target_netsuite_v2.sinks import (
     netsuiteV2Sink,
 )
 
 
-class TargetNetsuiteV2(Target):
+class TargetNetsuiteV2(TargetHotglue):
     """Sample target for netsuite-v2."""
 
     name = "target-netsuite-v2"
@@ -19,7 +19,11 @@ class TargetNetsuiteV2(Target):
         th.Property("ns_token_secret", th.StringType),
         th.Property("ns_account", th.StringType)
     ).to_dict()
-    default_sink_class = netsuiteV2Sink
+
+    SINK_TYPES = [netsuiteV2Sink]
+    
+    def get_sink_class(self, stream_name: str):
+        return netsuiteV2Sink
 
 
 if __name__ == "__main__":

--- a/target_netsuite_v2/tests/test_core.py
+++ b/target_netsuite_v2/tests/test_core.py
@@ -4,9 +4,9 @@ import datetime
 
 from typing import Dict, Any
 
-from singer_sdk.testing import get_standard_target_tests
+from hotglue_singer_sdk.testing import get_standard_target_tests
 
-from target_netsuite_v2.target import Targetnetsuite-v2
+from target_netsuite_v2.target import TargetNetsuiteV2
 
 SAMPLE_CONFIG: Dict[str, Any] = {
     # TODO: Initialize minimal target config
@@ -17,7 +17,7 @@ SAMPLE_CONFIG: Dict[str, Any] = {
 def test_standard_target_tests():
     """Run standard target tests from the SDK."""
     tests = get_standard_target_tests(
-        Targetnetsuite-v2,
+        TargetNetsuiteV2,
         config=SAMPLE_CONFIG,
     )
     for test in tests:


### PR DESCRIPTION
- changed `context["reference_data"]` to `self.reference_data`
- `process_record` renamed `preprocess_record` and instead of append on the `context["reference_data"]` it `return` the processed record
- `process_batch` renamed to `upsert_record`; added `record` as function argument; remove loop over the context to retrieve the records, example removed: `for record in context.get("Refund", []):`; `upsert_record` return state