### PR TITLE
HGI-10861: lazy-load reference data tables on first access

### DIFF
--- a/target_netsuite_v2/reference_data_store.py
+++ b/target_netsuite_v2/reference_data_store.py
@@ -1,0 +1,192 @@
+"""Lazy-loading store for NetSuite reference data tables."""
+
+from netsuitesdk.internal.exceptions import NetSuiteRequestError
+
+
+class ReferenceDataStore:
+    """Loads reference tables on first access instead of bulk-fetching at sink init."""
+
+    def __init__(self, sink):
+        self._sink = sink
+        self._data = {}
+        self._loading = set()
+
+    def get(self, key, default=None):
+        self._ensure_loaded(key)
+        return self._data.get(key, default)
+
+    def __getitem__(self, key):
+        self._ensure_loaded(key)
+        if key not in self._data:
+            raise KeyError(key)
+        return self._data[key]
+
+    def __contains__(self, key):
+        return key in self._data
+
+    def _ensure_loaded(self, key):
+        if key in self._data or key in self._loading:
+            return
+        self._loading.add(key)
+        try:
+            self._sink.logger.info(f"Loading reference data for {key}...")
+            rows = self._fetch(key)
+            if rows is not None:
+                self._data[key] = rows
+        finally:
+            self._loading.discard(key)
+
+    def _fetch(self, key):
+        sink = self._sink
+        loaders = {
+            "Classifications": self._load_classifications,
+            "Currencies": self._load_currencies,
+            "Departments": self._load_departments,
+            "Accounts": self._load_accounts,
+            "Locations": self._load_locations,
+            "Customers": self._load_customers,
+            "Jobs": self._load_jobs,
+            "Vendors": self._load_vendors,
+            "Subsidiaries": self._load_subsidiaries,
+        }
+        loader = loaders.get(key)
+        if loader is None:
+            sink.logger.warning(f"No reference data loader for key '{key}'")
+            return None
+        return loader()
+
+    def _load_classifications(self):
+        try:
+            return self._sink.ns_client.entities["Classifications"].get_all(["name"])
+        except Exception as e:
+            self._sink._check_exception(e, "Classifications")
+            return None
+
+    def _load_currencies(self):
+        try:
+            return self._sink.ns_client.entities["Currencies"].get_all()
+        except Exception as e:
+            self._sink._check_exception(e, "Currencies")
+            return None
+
+    def _load_departments(self):
+        try:
+            return self._sink.ns_client.entities["Departments"].get_all(["name"])
+        except Exception as e:
+            self._sink._check_exception(e, "Departments")
+            return None
+
+    def _load_accounts(self):
+        try:
+            return self._sink.ns_client.entities["Accounts"](
+                self._sink.ns_client.ns_client
+            ).get_all(
+                [
+                    "acctName",
+                    "acctNumber",
+                    "subsidiaryList",
+                    "acctType",
+                    "class",
+                    "department",
+                    "isInactive",
+                    "location",
+                ],
+                page_size=100,
+            )
+        except Exception as e:
+            if "You need  the 'Lists -> Documents and Files' permission" in str(e):
+                self._sink.logger.info(
+                    "Permissions for Documents and Files missing. "
+                    "Attempting to get Accounts with body_fields_only=True"
+                )
+                accounts = self._sink.ns_client.entities["Accounts"](
+                    self._sink.ns_client.ns_client, body_fields_only=True
+                ).get_all(
+                    [
+                        "acctName",
+                        "acctNumber",
+                        "subsidiaryList",
+                        "acctType",
+                        "class",
+                        "department",
+                        "isInactive",
+                        "location",
+                    ],
+                    page_size=100,
+                )
+                self._sink.ns_client.ns_client._search_preferences.bodyFieldsOnly = False
+                return accounts
+            self._sink._check_exception(e, "Accounts")
+            return None
+
+    def _load_locations(self):
+        try:
+            self._sink.ns_client.ns_client._search_preferences.bodyFieldsOnly = False
+            locations = self._sink.ns_client.entities["Locations"].get_all(
+                ["name", "subsidiaryList", "isInactive"], page_size=100
+            )
+            self._sink.logger.info(f"Locations: {locations}")
+            return locations
+        except NetSuiteRequestError as e:
+            message = e.message.replace("error", "failure").replace("Error", "")
+            self._sink.logger.warning(
+                f"It was not possible to retrieve Locations data: {message}"
+            )
+            return None
+        except Exception as e:
+            self._sink._check_exception(e, "Locations")
+            return None
+
+    def _load_customers(self):
+        try:
+            return self._sink.ns_client.entities["Customer"](
+                self._sink.ns_client.ns_client
+            ).get_all(["companyName", "isInactive", "subsidiary"], page_size=100)
+        except Exception as e:
+            self._sink._check_exception(e, "Customers")
+            return None
+
+    def _load_jobs(self):
+        try:
+            self._sink.logger.info("Fetching Jobs via REST SuiteQL...")
+            return self._sink.get_reference_jobs_rest()
+        except Exception as e:
+            self._sink._check_exception(e, "Jobs")
+            return None
+
+    def _load_vendors(self):
+        try:
+            self._sink.logger.info("Fetching Vendors via REST SuiteQL...")
+            vendors = self._sink.get_reference_vendors_rest()
+            if vendors:
+                return vendors
+        except Exception as e:
+            self._sink._check_exception(e, "Vendors")
+
+        try:
+            self._sink.logger.info("Fetching Vendors via SOAP")
+            return self._sink.ns_client.entities["Vendors"].get_all(
+                [
+                    "companyName",
+                    "firstName",
+                    "lastName",
+                    "altName",
+                    "isInactive",
+                    "externalId",
+                    "name",
+                    "subsidiary",
+                ],
+                page_size=100,
+            )
+        except Exception as e:
+            self._sink._check_exception(e, "Vendors")
+            return None
+
+    def _load_subsidiaries(self):
+        try:
+            return self._sink.ns_client.entities["Subsidiaries"].get_all(
+                ["name"], page_size=100
+            )
+        except Exception as e:
+            self._sink._check_exception(e, "Subsidiaries")
+            return None

--- a/target_netsuite_v2/reference_data_store.py
+++ b/target_netsuite_v2/reference_data_store.py
@@ -22,6 +22,7 @@ class ReferenceDataStore:
         return self._data[key]
 
     def __contains__(self, key):
+        self._ensure_loaded(key)
         return key in self._data
 
     def _ensure_loaded(self, key):
@@ -31,8 +32,7 @@ class ReferenceDataStore:
         try:
             self._sink.logger.info(f"Loading reference data for {key}...")
             rows = self._fetch(key)
-            if rows is not None:
-                self._data[key] = rows
+            self._data[key] = rows if rows is not None else []
         finally:
             self._loading.discard(key)
 

--- a/target_netsuite_v2/reference_data_store.py
+++ b/target_netsuite_v2/reference_data_store.py
@@ -10,6 +10,7 @@ class ReferenceDataStore:
         self._sink = sink
         self._data = {}
         self._loading = set()
+        self._failed_keys = set()
 
     def get(self, key, default=None):
         self._ensure_loaded(key)
@@ -25,14 +26,22 @@ class ReferenceDataStore:
         self._ensure_loaded(key)
         return key in self._data
 
+    def load_succeeded(self, key):
+        """Return True if the table was fetched successfully (may be empty)."""
+        self._ensure_loaded(key)
+        return key in self._data
+
     def _ensure_loaded(self, key):
-        if key in self._data or key in self._loading:
+        if key in self._data or key in self._loading or key in self._failed_keys:
             return
         self._loading.add(key)
         try:
             self._sink.logger.info(f"Loading reference data for {key}...")
             rows = self._fetch(key)
-            self._data[key] = rows if rows is not None else []
+            if rows is not None:
+                self._data[key] = rows
+            else:
+                self._failed_keys.add(key)
         finally:
             self._loading.discard(key)
 
@@ -157,9 +166,7 @@ class ReferenceDataStore:
     def _load_vendors(self):
         try:
             self._sink.logger.info("Fetching Vendors via REST SuiteQL...")
-            vendors = self._sink.get_reference_vendors_rest()
-            if vendors:
-                return vendors
+            return self._sink.get_reference_vendors_rest()
         except Exception as e:
             self._sink._check_exception(e, "Vendors")
 

--- a/target_netsuite_v2/rest_client.py
+++ b/target_netsuite_v2/rest_client.py
@@ -380,7 +380,7 @@ class netsuiteRestV2Sink(HotglueSink):
         
         if not sale_order.get("location") and record.get('subsidiary_id') and self.reference_data.get("Locations"):
             for location in self.reference_data["Locations"]:
-                for subsidiary in location.get("subsidiaryList", []):
+                for subsidiary in location.get("subsidiaryList") or []:
                     if str(record.get('subsidiary_id')) == subsidiary["internalId"]:
                         sale_order["location"] = {"id": location["internalId"]}
         

--- a/target_netsuite_v2/rest_client.py
+++ b/target_netsuite_v2/rest_client.py
@@ -133,8 +133,6 @@ class netsuiteRestV2Sink(HotglueSink):
 
         labels_checked = []
         for ref_key, label in ref_keys_and_labels:
-            if ref_key not in ref_data:
-                continue
             labels_checked.append(label.lower())
             ref_entry = self._find_ref_entry(ref_data, ref_key, value_id)
             if ref_entry is None:

--- a/target_netsuite_v2/rest_client.py
+++ b/target_netsuite_v2/rest_client.py
@@ -133,6 +133,11 @@ class netsuiteRestV2Sink(HotglueSink):
 
         labels_checked = []
         for ref_key, label in ref_keys_and_labels:
+            if hasattr(ref_data, "load_succeeded"):
+                if not ref_data.load_succeeded(ref_key):
+                    continue
+            elif ref_key not in ref_data:
+                continue
             labels_checked.append(label.lower())
             ref_entry = self._find_ref_entry(ref_data, ref_key, value_id)
             if ref_entry is None:

--- a/target_netsuite_v2/sinks.py
+++ b/target_netsuite_v2/sinks.py
@@ -53,7 +53,7 @@ class netsuiteV2Sink(netsuiteSoapV2Sink, netsuiteRestV2Sink):
         super().__init__(target, stream_name, schema, key_properties)
         
         self.get_ns_client()
-        self.reference_data = self.get_reference_data()
+        self.init_reference_data()
 
     
     def post_item(self, record):

--- a/target_netsuite_v2/soap_client.py
+++ b/target_netsuite_v2/soap_client.py
@@ -3,17 +3,15 @@
 from target_hotglue.sinks import HotglueSink
 from target_netsuite_v2.netsuite import NetSuite
 from target_netsuite_v2.zeep_soap_client import NetsuiteSoapClient
+from target_netsuite_v2.reference_data_store import ReferenceDataStore
 
-from netsuitesdk.internal.exceptions import NetSuiteRequestError
 import json
-import os
 import requests
 import base64
 
 from difflib import SequenceMatcher
 from heapq import nlargest as _nlargest
 from pendulum import parse
-from datetime import datetime
 
 class netsuiteSoapV2Sink(HotglueSink):
     """netsuite-v2 target sink class."""
@@ -111,98 +109,10 @@ class netsuiteSoapV2Sink(HotglueSink):
         
         return attachments_ids
 
-    def get_reference_data(self):
-        if self._target.reference_data:
-            return self._target.reference_data
-        
-        if self.config.get("snapshot_hours"):
-            try:
-                with open(f'{self.config.get("snapshot_dir", "snapshots")}/reference_data.json') as json_file:
-                    reference_data = json.load(json_file)
-                    if reference_data.get("write_date"):
-                        last_run = parse(reference_data["write_date"])
-                        last_run = last_run.replace(tzinfo=None)
-                        if (datetime.utcnow()-last_run).total_hours()<int(self.config.get("snapshot_hours")):
-                            return reference_data
-            except:
-                self.logger.info(f"Snapshot not found or not readable.")
-
-        self.logger.info(f"Reading data from API...")
-        reference_data = {}
-
-        try:
-            reference_data["Classifications"] = self.ns_client.entities["Classifications"].get_all(["name"])
-        except Exception as e:
-            self._check_exception(e, "Classifications")
-
-        try:
-            reference_data["Currencies"] = self.ns_client.entities["Currencies"].get_all()
-        except Exception as e:
-            self._check_exception(e, "Currencies")
-        
-        try:
-            reference_data["Departments"] = self.ns_client.entities["Departments"].get_all(["name"])
-        except Exception as e:
-            self._check_exception(e, "Departments")
-
-        try:
-            reference_data["Accounts"] = self.ns_client.entities["Accounts"](self.ns_client.ns_client).get_all(["acctName", "acctNumber", "subsidiaryList", "acctType", "class", "department", "isInactive", "location"], page_size=100)
-        except Exception as e:
-            if "You need  the 'Lists -> Documents and Files' permission" in str(e):
-                self.logger.info(f"Permissions for Documents and Files missing. Attempting to get Accounts with body_fields_only=True")
-                reference_data["Accounts"] = self.ns_client.entities["Accounts"](self.ns_client.ns_client, body_fields_only=True).get_all(["acctName", "acctNumber", "subsidiaryList", "acctType", "class", "department", "isInactive", "location"], page_size=100)
-                self.ns_client.ns_client._search_preferences.bodyFieldsOnly = False
-            else:
-                self._check_exception(e, "Accounts")
-
-        try:
-            reference_data["Locations"] = self.ns_client.entities["Locations"].get_all(["name", "subsidiaryList", "isInactive"], page_size=100)
-            self.logger.info(f"Locations: {reference_data['Locations']}")
-        except NetSuiteRequestError as e:
-            message = e.message.replace("error", "failure").replace("Error", "")
-            self.logger.warning(f"It was not possible to retrieve Locations data: {message}")
-        except Exception as e:
-            self._check_exception(e, "Locations")
-
-        try:
-            reference_data["Customers"] = self.ns_client.entities["Customer"](self.ns_client.ns_client).get_all(["companyName", "isInactive", "subsidiary"], page_size=100)
-        except Exception as e:
-            self._check_exception(e, "Customers")
-
-        try:
-            self.logger.info("Fetching Jobs via REST SuiteQL...")
-            reference_data["Jobs"] = self.get_reference_jobs_rest()
-        except Exception as e:
-            self._check_exception(e, "Jobs")
-
-        try:
-            self.logger.info("Fetching Vendors via REST SuiteQL...")
-            reference_data["Vendors"] = self.get_reference_vendors_rest()
-        except Exception as e:
-            self._check_exception(e, "Vendors")
-        
-        if "Vendors" not in reference_data:
-            try:
-                self.logger.info("Fetching Vendors via SOAP")
-                reference_data["Vendors"] = self.ns_client.entities["Vendors"].get_all(["companyName", "firstName", "lastName", "altName", "isInactive", "externalId","name", "subsidiary"], page_size=100)
-            except Exception as e:
-                self._check_exception(e, "Vendors")
-
-        try:
-            reference_data["Subsidiaries"] = self.ns_client.entities["Subsidiaries"].get_all(["name"], page_size=100)
-        except Exception as e:
-            self._check_exception(e, "Subsidiaries")
-
-        if self.config.get("snapshot_hours"):
-            reference_data["write_date"] = datetime.utcnow().isoformat()
-            os.makedirs("snapshots", exist_ok=True)
-            with open('snapshots/reference_data.json', 'w') as outfile:
-                json.dump(reference_data, outfile)
-
-
-        # Cache reference data in target
-        self._target.reference_data = reference_data
-        return reference_data
+    def init_reference_data(self):
+        if self._target.reference_data is None:
+            self._target.reference_data = ReferenceDataStore(self)
+        self.reference_data = self._target.reference_data
 
     def process_journal_entry(self, context, record):
         subsidiaries = {}
@@ -436,7 +346,7 @@ class netsuiteSoapV2Sink(HotglueSink):
             cost = cogsAccount.get('unitPrice')
             accountName = cogsAccount.get('accountName')
             id = cogsAccount.get('accountId')
-            account = list(filter(lambda x: get_account_by_name_or_id(x,accountName,id), context['reference_data']['Accounts']))[0]
+            account = list(filter(lambda x: get_account_by_name_or_id(x,accountName,id), self.reference_data["Accounts"]))[0]
             item.costEstimate = cost
             item.cogsAccount = RecordRef(internalId = account['internalId'])
         
@@ -455,7 +365,7 @@ class netsuiteSoapV2Sink(HotglueSink):
             id = invoiceAccount.get('accountId')
             if accountName or id:
                 try:
-                    account = list(filter(lambda x: get_account_by_name_or_id(x, accountName, id), context['reference_data']['Accounts']))[0]
+                    account = list(filter(lambda x: get_account_by_name_or_id(x, accountName, id), self.reference_data["Accounts"]))[0]
                     item.incomeAccount = RecordRef(internalId=account['internalId'])
                 except IndexError:
                     self.logger.error(f"Account not found for {accountName} or {id}")

--- a/templates/config.json
+++ b/templates/config.json
@@ -3,7 +3,5 @@
   "ns_consumer_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "ns_token_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "ns_token_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-  "ns_account": "xxxxxxxxxxxx",
-  "snapshot_hours": 24,
-  "snapshot_dir": "snapshots"
+  "ns_account": "xxxxxxxxxxxx"
 }


### PR DESCRIPTION
Each sink used to bulk-fetch all reference tables at init (Classifications, Departments, Accounts, Locations, Customers, Jobs, Vendors, Subsidiaries, etc.), even when records only passed internal IDs. On large accounts this meant minutes of SOAP paging before the first bill posted.

This PR introduces `ReferenceDataStore`, which loads each table on first access and caches it on the target for the rest of the job. ID-only payloads no longer trigger a Customers bulk load. The legacy `snapshot_hours` file cache is removed.

- Lazy per-table loading on first `get()` / `__getitem__`, shared across sinks via `target.reference_data`
- Vendors and Jobs still prefer REST SuiteQL bulk when those tables are first needed; other tables use the existing SOAP `get_all` paths
- Locations fetch sets `bodyFieldsOnly=False` so `subsidiaryList` is populated when Locations loads before Accounts
- `process_item` reads `self.reference_data` instead of the broken `context['reference_data']` path
- SalesOrders handles `subsidiaryList=None` on location records

## Changed files
- **`target_netsuite_v2/reference_data_store.py`** — New lazy-loading store with per-table loaders moved from `get_reference_data()`.
- **`target_netsuite_v2/soap_client.py`** — Replaces bulk `get_reference_data()` with `init_reference_data()`; removes snapshot read/write logic.
- **`target_netsuite_v2/sinks.py`** — Calls `init_reference_data()` at sink init.
- **`target_netsuite_v2/rest_client.py`** — Treats null `subsidiaryList` as empty in `process_order`.
- **`templates/config.json`** — Removes `snapshot_hours` and `snapshot_dir`.